### PR TITLE
[FOS-6143] Update usbmount configuration

### DIFF
--- a/usbmount.conf
+++ b/usbmount.conf
@@ -46,7 +46,7 @@ MOUNTOPTIONS="noexec,nodev,noatime,nodiratime,dirsync,loud,rw"
 # For example, "-fstype=vfat,gid=floppy,dmask=0007,fmask=0117" would add
 # the options "gid=floppy,dmask=0007,fmask=0117" when a vfat filesystem
 # is mounted.
-FS_MOUNTOPTIONS="-fstype=vfat,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=ntfs,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=ext2,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=ext3,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=ext4,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=hfsplus,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=fuseblk,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=ntfs-3g,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=fuse,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=msdos,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=umsdos,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=fat,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8"
+FS_MOUNTOPTIONS="-fstype=vfat,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8=true -fstype=ntfs,uid=1000,gid=1000,dmask=0007,fmask=0177,nls=utf8 -fstype=ext2,nogrpid -fstype=ext3,nogrpid -fstype=ext4,nogrpid -fstype=hfsplus,umask=0177 -fstype=fuseblk,user_id=1000,group_id=1000,dmask=0007,fmask=0177 -fstype=ntfs-3g,uid=1000,gid=1000,dmask=0007,fmask=0177 -fstype=fuse,user_id=1000,group_id=1000,dmask=0007,fmask=0177 -fstype=msdos,uid=1000,gid=1000,dmask=0007,fmask=0177,flush -fstype=umsdos,uid=1000,gid=1000,dmask=0007,fmask=0177,flush -fstype=fat,uid=1000,gid=1000,dmask=0007,fmask=0177,flush"
 
 # If set to "yes", more information will be logged via the syslog
 # facility.

--- a/usbmount.conf
+++ b/usbmount.conf
@@ -14,7 +14,7 @@ MOUNTPOINTS="/media/usb0 /media/usb1 /media/usb2 /media/usb3
 
 # Filesystem types: removable storage devices are only mounted if they
 # contain a filesystem type which is in this list.
-FILESYSTEMS="vfat exfat ntfs ext2 ext3 ext4 hfsplus"
+FILESYSTEMS="vfat ntfs ext2 ext3 ext4 hfsplus fuseblk ntfs-3g fuse msdos umsdos fat"
 
 #############################################################################
 # WARNING!                                                                  #
@@ -35,7 +35,7 @@ FILESYSTEMS="vfat exfat ntfs ext2 ext3 ext4 hfsplus"
 #############################################################################
 # Mount options: Options passed to the mount command with the -o flag.
 # See the warning above regarding removing "sync" from the options.
-MOUNTOPTIONS="noexec,nodev,noatime,nodiratime"
+MOUNTOPTIONS="noexec,nodev,noatime,nodiratime,dirsync,loud,rw"
 
 # Filesystem type specific mount options: This variable contains a space
 # separated list of strings, each which the form "-fstype=TYPE,OPTIONS".
@@ -46,8 +46,8 @@ MOUNTOPTIONS="noexec,nodev,noatime,nodiratime"
 # For example, "-fstype=vfat,gid=floppy,dmask=0007,fmask=0117" would add
 # the options "gid=floppy,dmask=0007,fmask=0117" when a vfat filesystem
 # is mounted.
-FS_MOUNTOPTIONS="-fstype=vfat,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=exfat,uid=1000,gid=1000,dmask=0007,fmask=0177 -fstype=ntfs,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8"
+FS_MOUNTOPTIONS="-fstype=vfat,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=ntfs,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=ext2,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=ext3,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=ext4,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=hfsplus,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=fuseblk,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=ntfs-3g,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=fuse,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=msdos,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=umsdos,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8 -fstype=fat,uid=1000,gid=1000,dmask=0007,fmask=0177,flush,utf8"
 
 # If set to "yes", more information will be logged via the syslog
 # facility.
-VERBOSE=no
+VERBOSE=yes


### PR DESCRIPTION
ticket: https://readyrobotics.atlassian.net/browse/FOS-6143

vfat, ext2, ext3, ext4, fuseblk, fuse, fat may be found in /proc/filesystems
ntfs, hfsplus, msdos may be found in /lib/modules/$(uname -r)/kernel/fs (ls /lib/modules/$(uname -r)/kernel/fs/*/*ko)

Package `dosfstools_4.1-2_amd64.deb` will likely need to be installed to support the `msdos` filesystem type.
msdos limits the file extension length to 3 characters, so while MSDOS filesystem is incompatible with the update file extension .forge, perhaps it would be useful for robot drivers.

`umsdos` is specified, but  `umsdos` was last updated over a decade ago. `umsdos` was last supported in the 2.4 kernel.

The support for mount options is loosely documented in `mount`'s manpages, but it appears that all previously listed options are supported for all requested filesystems.